### PR TITLE
(dep) replaces coffee-script with coffeescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/chai": "^3.4.35",
     "chai": "^3.5.0",
-    "coffee-script": "^1.12.4",
+    "coffeescript": "^1.12.4",
     "core-js": "^2.4.1",
     "coveralls": "^2.12.0",
     "eslint": "^3.18.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --recursive
 --reporter dot
---compilers coffee:coffee-script/register
+--compilers coffee:coffeescript/register


### PR DESCRIPTION
Fixes depreceation warning:

> npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)

