### PR TITLE
Makes chai-iterator compatible with chai 4; closes #12

### DIFF
--- a/chai-iterator.js
+++ b/chai-iterator.js
@@ -63,7 +63,7 @@
 
   Assertion.addProperty('for', noop);
 
-  Assertion.overwriteMethod('lengthOf', function(_super) {
+  Assertion.overwriteChainableMethod('lengthOf', function(_super) {
     return function(exp) {
         if (utils.flag(this, 'iterate')) {
           var len = iterableLength(this._obj, exp);
@@ -79,6 +79,10 @@
       } else {
         _super.apply(this, arguments);
       }
+    };
+  }, function(_super) {
+    return function() {
+      _super.apply(this);
     };
   });
 

--- a/chai-iterator.js
+++ b/chai-iterator.js
@@ -65,8 +65,8 @@
 
   Assertion.overwriteChainableMethod('lengthOf', function(_super) {
     return function(exp) {
-        if (utils.flag(this, 'iterate')) {
-          var len = iterableLength(this._obj, exp);
+      if (utils.flag(this, 'iterate')) {
+        var len = iterableLength(this._obj, exp);
 
         this.assert(
           len === exp,

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   },
   "homepage": "https://github.com/mcmath/chai-iterator",
   "peerDependencies": {
-    "chai": "3.x"
+    "chai": "4.x"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "coffee-script": "^1.12.4",
     "core-js": "^2.4.1",
     "coveralls": "^2.12.0",


### PR DESCRIPTION
This is a breaking change.

Applying either 18246bb or cc0cab6 by itself causes tests to fail.

Mergin this pr would require bumping npm to version 2.